### PR TITLE
don't set number of pool workers

### DIFF
--- a/src/pypore/sampledata/tests/test_creator.py
+++ b/src/pypore/sampledata/tests/test_creator.py
@@ -147,8 +147,8 @@ class TestCreateRandomData(unittest.TestCase):
         n_events_returned_arr = []
         n_events_found_arr = []
 
-        trials = 10
-        p = Pool(trials)
+        trials = 15
+        p = Pool()
 
         args = []
         # create a list of file_names so we can average the number of events.


### PR DESCRIPTION
travis build 115 failed twice with the stack trace below:

```
======================================================================
ERROR: test_number_of_events (pypore.sampledata.tests.test_creator.TestCreateRandomData)
Tests that the number of events is roughly correct. The number of events should be random, which is why
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/parkin/pypore/src/pypore/tests/util.py", line 28, in wrap
    function(*args, filename=filename, **kwargs)
  File "/home/travis/build/parkin/pypore/src/pypore/sampledata/tests/test_creator.py", line 151, in test_number_of_events
    p = Pool(trials)
  File "/usr/lib/python2.7/multiprocessing/__init__.py", line 232, in Pool
    return Pool(processes, initializer, initargs, maxtasksperchild)
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 136, in __init__
    self._repopulate_pool()
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 199, in _repopulate_pool
    w.start()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 130, in start
    self._popen = Popen(self)
  File "/usr/lib/python2.7/multiprocessing/forking.py", line 120, in __init__
    self.pid = os.fork()
OSError: [Errno 12] Cannot allocate memory
```

Not setting the number of workers in the Pool (to a high number like 10!) should hopefully fix this.
